### PR TITLE
Fix example config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://example.com/"
 languageCode = "en-us"
-theme = "0x-32"
+theme = "hugo-theme-fiber"
 paginate = 5
 
 [params]


### PR DESCRIPTION
Update the example site config to point to `hugo-theme-fiber`